### PR TITLE
Add the layout file for lyx use

### DIFF
--- a/isabec.layout
+++ b/isabec.layout
@@ -1,0 +1,263 @@
+#% Do not delete the line below; configure depends on this
+#  \DeclareLaTeXClass[isabec]{ISABE Paper}
+#  \DeclareCategory{Articles}
+
+Format 66
+
+# Input general definitions
+Input stdclass.inc
+
+Provides apalike 1
+
+# Global parameters
+Columns                 1
+Sides                   2
+SecNumDepth             3
+TocDepth                3
+DefaultStyle            Standard
+
+# Standard style definition
+Style Standard
+	Category              MainText
+	Margin                Static
+	LatexType             Paragraph
+	LatexName             dummy
+	ParIndent             MM
+	ParSkip               0.4
+	Align                 Block
+	AlignPossible         Block, Left, Right, Center
+	LabelType             No_Label
+End
+
+# Section style definition
+Style Section
+	Category              Sectioning
+	Margin                Dynamic
+	LatexType             Command
+	LatexName             section
+	NeedProtect           1
+	NextNoIndent          1
+	LabelSep              xxx
+	ParSkip               0.4
+	TopSep                1.3
+	BottomSep             0.7
+	ParSep                0.7
+	Align                 Block
+	Font
+	  Series              Bold
+	  Size                Large
+	EndFont
+	TocLevel 1
+End
+
+# Subsection style definition
+Style Subsection
+	CopyStyle             Section
+	LatexName             subsection
+	Margin                Static
+	LeftMargin            MM
+	Font
+	  Series              Bold
+	  Size                Normal
+	EndFont
+	TocLevel 2
+End
+
+# Title style definition
+Style Title
+	Category              FrontMatter
+	Margin                Static
+	LatexType             Command
+	LatexName             title
+	ParSkip               0.4
+	ItemSep               0
+	TopSep                0
+	BottomSep             1
+	ParSep                1
+	Align                 Center
+	LabelType             No_Label
+	Font
+	  Family              Sans
+	  Series              Bold
+	  Size                Largest
+	EndFont
+End
+
+# Author style definition
+Style Author
+	Category              FrontMatter
+	Margin                Static
+	LatexType             Command
+	LatexName             author
+	ParSkip               0.4
+	TopSep                1.3
+	BottomSep             0.7
+	ParSep                0.7
+	Align                 Center
+	LabelType             No_Label
+	Font
+	  Family              Sans
+	  Series              Bold
+	  Size                Normal
+	EndFont
+End
+
+# Abstract style definition
+Style Abstract
+	Margin                Static
+	LatexType             Environment
+	LatexName             abstract
+	Category              FrontMatter
+	NextNoIndent          1
+	LeftMargin            MMM
+	RightMargin           MMM
+	ParIndent             MM
+	ItemSep               0
+	TopSep                0.7
+	BottomSep             0.7
+	ParSep                0
+	Align                 Block
+	LabelType             Centered
+	LabelString           "Abstract"
+	LabelBottomSep        0.5
+	Font
+	  Size                Small
+	EndFont
+	LabelFont
+	  Series              Bold
+	  Size                Large
+	EndFont
+End
+
+# Jyear style definition
+Style Jyear
+	Category              FrontMatter
+	LatexType             Command
+	LatexName             jyear
+	Margin                Dynamic
+	LabelType             Static
+	LabelString           "Conference Year:"
+	LabelSep              M
+	ParSkip               0.4
+	TopSep                0.9
+	BottomSep             0.5
+	ParSep                0.5
+	Align                 Block
+	AlignPossible         Block, Left
+	LabelFont
+	  Series              Bold
+	EndFont
+End
+
+# Jnumber style definition
+Style Jnumber
+	Category              FrontMatter
+	LatexType             Command
+	LatexName             jnumber
+	Margin                Dynamic
+	LabelType             Static
+	LabelString           "Manuscript Number:"
+	LabelSep              M
+	ParSkip               0.4
+	TopSep                0.9
+	BottomSep             0.5
+	ParSep                0.5
+	Align                 Block
+	AlignPossible         Block, Left
+	LabelFont
+	  Series              Bold
+	EndFont
+End
+
+# Theorem-like environments
+Style Theorem
+	Category              Reasoning
+	Margin                First_Dynamic
+	LatexType             Environment
+	LatexName             theorem
+	NextNoIndent          1
+	Argument 1
+	  LabelString         "Additional Theorem Text"
+	  Tooltip             "Additional text appended to the theorem header"
+	EndArgument
+	LabelSep              xx
+	ParSkip               0.4
+	ItemSep               0.2
+	TopSep                0.7
+	BottomSep             0.7
+	ParSep                0.3
+	Align                 Block
+	AlignPossible         Left, Right, Center
+	LabelType             Static
+	LabelCounter          theorem
+	LabelString           "Theorem \thetheorem."
+	Font
+	  Shape               Italic
+	  Size                Normal
+	EndFont
+	LabelFont
+	  Shape               Up
+	  Series              Bold
+	EndFont
+End
+
+Style Lemma
+	CopyStyle             Theorem
+	LatexName             lemma
+	LabelString           "Lemma \thelemma."
+End
+
+Style Corollary
+	CopyStyle             Theorem
+	LatexName             corollary
+	LabelString           "Corollary \thecorollary."
+End
+
+Style Proposition
+	CopyStyle             Theorem
+	LatexName             proposition
+	LabelString           "Proposition \theproposition."
+End
+
+Style Definition
+	CopyStyle             Theorem
+	LatexName             definition
+	LabelString           "Definition \thedefinition."
+	Font
+	  Shape               Up
+	EndFont
+	LabelFont
+	  Shape               Up
+	  Series              Bold
+	EndFont
+End
+
+Style Proof
+	Category              Reasoning
+	Margin                First_Dynamic
+	LatexType             Environment
+	LatexName             proof
+	NextNoIndent          1
+	Argument 1
+	  LabelString         "Alternative Proof String"
+	  Tooltip             "An alternative name for the proof"
+	EndArgument
+	LabelSep              xx
+	ParSkip               0.4
+	ItemSep               0.2
+	TopSep                0.6
+	BottomSep             0.6
+	ParSep                0.3
+	Align                 Block
+	AlignPossible         Left, Right, Center
+	LabelType             Static
+	LabelString           "Proof."
+	EndLabelType          Box
+	Font
+	  Shape               Up
+	  Size                Normal
+	EndFont
+	LabelFont
+	  Shape               Italic
+	EndFont
+End


### PR DESCRIPTION
here is a simple layout file to use the template with LyX 

the folowing lines can be added in the LaTeX preamble of LyX:


%% The preamble begins here.
\usepackage[super,comma,round]{natbib}
\usepackage[figuresleft]{rotating}
\usepackage{txfonts}

% Metadata Information
\jyear{2024}%% conference year
\jnumber{xxx} %% manuscript number

\author{A. One, B. A. Two, A. Three \email{a.one@toto.com}} 
\affil{Toto S.A., City, Country}

% Co-authors 
\author{A. Four} 
\affil{Tata GmbH, City, Country} 
\author{A. Five, A. Seven} 
\affil{Titi Ltd, City, Country}
\author{A. Eight} 
\affil{Tutu Inc, City, Country}

% Produces the title \maketitle  
